### PR TITLE
Add CI to automatically create new releases

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -49,7 +49,7 @@ jobs:
             for f in ./$subfolder/*.rdvpreset
             do
               echo $f
-              mv $f ${f/current/"$MONTH_LONG-YEAR"}
+              mv $f ${f/current/"$MONTH_LONG-$YEAR"}
             done
           done
           tree .

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -34,13 +34,6 @@ jobs:
           echo "MONTH_LONG=$month_long" >> $GITHUB_ENV
           echo "MONTH_LONG_UPPER=$month_long_upper" >> $GITHUB_ENV
           echo "YEAR=$year" >> $GITHUB_ENV
-
-      - name: echo test
-        run: |
-          echo $MONTH_SHORT
-          echo $MONTH_LONG
-          echo $YEAR
-          echo $FOLDERS
           
       - name: Rename Presets in preperation for upload
         run: |
@@ -69,13 +62,13 @@ jobs:
       #    path: ./*.zip
 
 
-      - name: Upload binaries to release
+      - name: Create Tag and Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file_glob: true
           file: ./*.zip
           asset_name: mything
-          tag: weekly-settings-${{ env.MONTH_SHORT }}-${{ env.YEAR }}-20
+          tag: weekly-settings-${{ env.MONTH_SHORT }}-${{ env.YEAR }}
           release_name: Prime/Echoes/CGC Weekly Settings (${{ env.MONTH_LONG_UPPER }} ${{ env.YEAR }})
           body: "Current presets for all Prime/Echoes/CGC weeklies as of ${{ env.MONTH_LONG_UPPER }} ${{ env.YEAR }}."

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -46,12 +46,12 @@ jobs:
           echo $MONTH_SHORT
           echo $MONTH_LONG
           echo $YEAR
-          echo $env.FOLDERS
+          echo $FOLDERS
           
       - name: Rename Presets in preperation for upload
         run: |
           
-          for subfolder in "${env.FOLDERS[@]}"
+          for subfolder in "${FOLDERS[@]}"
           do
             for f in ./$subfolder/*.rdvpreset
             do

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -43,7 +43,7 @@ jobs:
           
       - name: rename
         run: |
-          for $f in ./**.rdvpreset
+          for f in ./**.rdvpreset
           do
             echo $f
             mv $f ${f/current/"$MONTH_LONG-YEAR"}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -67,7 +67,6 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file_glob: true
           file: ./*.zip
-          asset_name: mything
           tag: weekly-settings-${{ env.MONTH_SHORT }}-${{ env.YEAR }}
           release_name: Prime/Echoes/CGC Weekly Settings (${{ env.MONTH_LONG_UPPER }} ${{ env.YEAR }})
           body: "Current presets for all Prime/Echoes/CGC weeklies as of ${{ env.MONTH_LONG_UPPER }} ${{ env.YEAR }}."

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           export LANG=C
           month=$(date +%b) 
+          month="${month,,}
           year=$(date +%Y)
           echo "MONTH=$month" >> $GITHUB_ENV
           echo "YEAR=$year" >> $GITHUB_ENV

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-        FOLDERS: "Prime" "Echoes" "CGC"
+        FOLDERS: "Prime Echoes CGC"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -2,31 +2,22 @@
 
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
-  # Allows you to run this workflow manually from the Actions tab
+    # branches: [ "main" ]
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     env:
         FOLDERS: "Prime Echoes CGC"
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      # Runs a single command using the runners shell
       - name: Set environment variables
         run: |
           export LANG=C
@@ -69,14 +60,17 @@ jobs:
           done
           ls
         
-      - uses: actions/upload-artifact@v4
+      #- uses: actions/upload-artifact@v4
+      #  with:
+      #    name: my-artifact
+      #    path: ./*.zip
+
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
         with:
-          name: my-artifact
-          path: ./*.zip
-
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./*.zip
+          asset_name: mything
+          tag: weekly-settings-$MONTH-SHORT-$YEAR-10
+          body: "This is my release text"

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -17,8 +17,12 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    env:
+        FOLDERS: ("Prime" "Echoes" "CGC")
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+    
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
@@ -29,7 +33,6 @@ jobs:
           month_short=$(date +%b) 
           month_long=$(date +%B) 
           year=$(date +%Y)
-          declare -a folders=("Prime" "Echoes" "CGC")
           
           month_short="${month_short,,}"
           month_long="${month_long,,}"
@@ -37,21 +40,18 @@ jobs:
           echo "MONTH_SHORT=$month_short" >> $GITHUB_ENV
           echo "MONTH_LONG=$month_long" >> $GITHUB_ENV
           echo "YEAR=$year" >> $GITHUB_ENV
-          echo "FOLDERS=$folders" >> $GITHUB_ENV
-          
-          
 
       - name: echo test
         run: |
           echo $MONTH_SHORT
           echo $MONTH_LONG
           echo $YEAR
-          echo $FOLDERS
+          echo $env.FOLDERS
           
       - name: Rename Presets in preperation for upload
         run: |
           
-          for subfolder in "${FOLDERS[@]}"
+          for subfolder in "${env.FOLDERS[@]}"
           do
             for f in ./$subfolder/*.rdvpreset
             do

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for subfolder in $FOLDERS
           do
-            zip ${subfolder,,}-weekly-settings-$MONTH_SHORT-$YEAR.zip ./$subfolder/*.rdvpreset
+            zip -j ${subfolder,,}-weekly-settings-$MONTH_SHORT-$YEAR.zip ./$subfolder/*.rdvpreset
           done
           ls
         

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -26,16 +26,29 @@ jobs:
       - name: Set month and year
         run: |
           export LANG=C
-          month=$(date +%b) 
-          month="${month,,}"
+          month_short=$(date +%b) 
+          month_long=$(date +%B) 
+          month_short="${month_short,,}"
+          month_long="${month_long,,}"
           year=$(date +%Y)
-          echo "MONTH=$month" >> $GITHUB_ENV
+          echo "MONTH_SHORT=$month_short" >> $GITHUB_ENV
+          echo "MONTH_LONG=$month_long" >> $GITHUB_ENV
           echo "YEAR=$year" >> $GITHUB_ENV
 
       - name: echo
         run: |
-          echo $MONTH
+          echo $MONTH_SHORT
+          echo $MONTH_LONG
           echo $YEAR
+          
+      - name: rename
+        run: |
+          for $f in ./**.rdvpreset
+          do
+            echo $f
+            mv $f ${f/current/"$MONTH_LONG-YEAR"}
+          done
+          tree .
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           export LANG=C
           month=$(date +%b) 
-          month="${month,,}
+          month="${month,,}"
           year=$(date +%Y)
           echo "MONTH=$month" >> $GITHUB_ENV
           echo "YEAR=$year" >> $GITHUB_ENV

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Rename Presets in preperation for upload
         run: |
           
-          for subfolder in "${FOLDERS[@]}"
+          for subfolder in "$FOLDERS"
           do
             for f in ./$subfolder/*.rdvpreset
             do

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-        FOLDERS: ("Prime" "Echoes" "CGC")
+        FOLDERS: "Prime" "Echoes" "CGC"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -23,28 +23,35 @@ jobs:
       - uses: actions/checkout@v4
 
       # Runs a single command using the runners shell
-      - name: Set month and year
+      - name: Set environment variables
         run: |
           export LANG=C
           month_short=$(date +%b) 
           month_long=$(date +%B) 
+          year=$(date +%Y)
+          declare -a folders=("Prime" "Echoes" "CGC")
+          
           month_short="${month_short,,}"
           month_long="${month_long,,}"
-          year=$(date +%Y)
+          
           echo "MONTH_SHORT=$month_short" >> $GITHUB_ENV
           echo "MONTH_LONG=$month_long" >> $GITHUB_ENV
           echo "YEAR=$year" >> $GITHUB_ENV
+          echo "FOLDERS=$folders" >> $GITHUB_ENV
+          
+          
 
-      - name: echo
+      - name: echo test
         run: |
           echo $MONTH_SHORT
           echo $MONTH_LONG
           echo $YEAR
+          echo $FOLDERS
           
-      - name: rename
+      - name: Rename Presets in preperation for upload
         run: |
-          declare -a folders=("Prime" "Echoes" "CGC")
-          for subfolder in "${folders[@]}"
+          
+          for subfolder in "${FOLDERS[@]}"
           do
             for f in ./$subfolder/*.rdvpreset
             do
@@ -53,6 +60,10 @@ jobs:
             done
           done
           tree .
+
+      - name: Create zips
+        run: |
+        
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -43,10 +43,14 @@ jobs:
           
       - name: rename
         run: |
-          for f in ./**.rdvpreset
+          declare -a folders=("Prime" "Echoes" "CGC")
+          for subfolder in "${folders[@]}"
           do
-            echo $f
-            mv $f ${f/current/"$MONTH_LONG-YEAR"}
+            for f in ./$subfolder/*.rdvpreset
+            do
+              echo $f
+              mv $f ${f/current/"$MONTH_LONG-YEAR"}
+            done
           done
           tree .
 

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,43 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Set month and year
+        run: |
+          export LANG=C
+          month=$(date +%b) 
+          year=$(date +%Y)
+          echo "MONTH=month" >> $GITHUB_ENV
+          echo "YEAR=year" >> $GITHUB_ENV
+
+      - name: echo
+        run: |
+          echo $MONTH
+          echo $YEAR
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -3,8 +3,7 @@
 name: CI
 
 on:
-  push:
-    # branches: [ "main" ]
+  # Only manual trigger
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -73,5 +73,6 @@ jobs:
           file_glob: true
           file: ./*.zip
           asset_name: mything
-          tag: weekly-settings-$MONTH-SHORT-$YEAR-10
+          tag: weekly-settings-${{ env.MONTH_SHORT }}-${{ env.YEAR }}-10
+          release_name: Prime/Echoes/CGC Weekly Settings (${{ env.MONTH_LONG }} ${{ env.YEAR }})
           body: "This is my release text"

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -51,8 +51,9 @@ jobs:
       - name: Rename Presets in preperation for upload
         run: |
           
-          for subfolder in "$FOLDERS"
+          for subfolder in $FOLDERS
           do
+            echo $subfolder
             for f in ./$subfolder/*.rdvpreset
             do
               echo $f

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -23,13 +23,16 @@ jobs:
           export LANG=C
           month_short=$(date +%b) 
           month_long=$(date +%B) 
+          month_long_upper=$month_long
           year=$(date +%Y)
           
           month_short="${month_short,,}"
           month_long="${month_long,,}"
           
+          
           echo "MONTH_SHORT=$month_short" >> $GITHUB_ENV
           echo "MONTH_LONG=$month_long" >> $GITHUB_ENV
+          echo "MONTH_LONG_UPPER=$month_long_upper" >> $GITHUB_ENV
           echo "YEAR=$year" >> $GITHUB_ENV
 
       - name: echo test
@@ -73,6 +76,6 @@ jobs:
           file_glob: true
           file: ./*.zip
           asset_name: mything
-          tag: weekly-settings-${{ env.MONTH_SHORT }}-${{ env.YEAR }}-10
-          release_name: Prime/Echoes/CGC Weekly Settings (${{ env.MONTH_LONG }} ${{ env.YEAR }})
-          body: "This is my release text"
+          tag: weekly-settings-${{ env.MONTH_SHORT }}-${{ env.YEAR }}-20
+          release_name: Prime/Echoes/CGC Weekly Settings (${{ env.MONTH_LONG_UPPER }} ${{ env.YEAR }})
+          body: "Current presets for all Prime/Echoes/CGC weeklies as of ${{ env.MONTH_LONG_UPPER }} ${{ env.YEAR }}."

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -50,7 +50,6 @@ jobs:
           
       - name: Rename Presets in preperation for upload
         run: |
-          
           for subfolder in $FOLDERS
           do
             echo $subfolder
@@ -64,7 +63,17 @@ jobs:
 
       - name: Create zips
         run: |
+          for subfolder in $FOLDERS
+          do
+            zip ${subfolder,,}-weekly-settings-$MONTH_SHORT-$YEAR.zip ./$subfolder/*.rdvpreset
+          done
+          ls
         
+      - uses: actions/upload-artifact@v4
+        with:
+          name: my-artifact
+          path: ./*.zip
+
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -28,8 +28,8 @@ jobs:
           export LANG=C
           month=$(date +%b) 
           year=$(date +%Y)
-          echo "MONTH=month" >> $GITHUB_ENV
-          echo "YEAR=year" >> $GITHUB_ENV
+          echo "MONTH=$month" >> $GITHUB_ENV
+          echo "YEAR=$year" >> $GITHUB_ENV
 
       - name: echo
         run: |

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -70,6 +70,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file_glob: true
           file: ./*.zip
           asset_name: mything
           tag: weekly-settings-$MONTH-SHORT-$YEAR-10

--- a/README.md
+++ b/README.md
@@ -17,11 +17,20 @@ Version zips will be iterated with dates for posterity of old presets.
 
 # Maintainers
 
-When updating preset zips, please create a new release with the tag format "weekly-settings-month-year" and upload the new zip along with the other game's current zip. Use the same format for the zip filenames with the games' name appended to the front of the zip. Bonus points for including a screenshot of preset info from Caretaker Class Drone.\
-*(Tag Example: "weekly-settings-feb-2023")\
-(Zip Example: "prime-weekly-settings-feb-2023.zip")*
+When updating preset zips, please do the following: 
 
-Then edit/replace the files in [Prime](./Prime/), [Echoes](./Echoes/), or [CGC](CGC).\
-*(File Examples:*\
-*"echoes-standard-weekly-settings-current.rdvpreset"*\
-*"cgc-prime-weekly-settings-current.rdvpreset")*
+1. Edit/replace the presets in [Prime](./Prime/), [Echoes](./Echoes/), or [CGC](CGC).\
+   If you add new presets, make sure that they're following the format of `<game>-<setting>-weekly-settings-current.rdvpreset`.
+  *(File Examples:*\
+  *"echoes-standard-weekly-settings-current.rdvpreset"*\
+  *"cgc-prime-weekly-settings-current.rdvpreset"*\
+  *"prime-door-lock-weekly-settings-current.rdvpreset"*)
+
+
+2. Go to the [Workflow Page](https://github.com/Miepee/Metroid-Prime-Randomizer-Weeklies/actions/workflows/blank.yml) and click on the "Run Workflow" button.
+  ![grafik](https://github.com/user-attachments/assets/c72725d2-c6d9-492c-9079-3c8583959c9a)
+
+3. Wait for the Release to get created.
+
+4. Edit the latest release and add screenshots of the Caretake Class Drone preset info.
+


### PR DESCRIPTION
Example of what it does in action: https://github.com/Miepee/Metroid-Prime-Randomizer-Weeklies/releases

TLDR; when explicitly prompted to do so, it makes a new tag with the current month/date, gets the current presets, renames them locally and uploads them

In the future this could probably be expanded to autoamtically create collapsable lists with all the info that the caretaker creates so that one doesn't have to create screenshots manually, but currently was too lazy for that.

Please squash on merge